### PR TITLE
Improved error messages

### DIFF
--- a/shi7/shi7.py
+++ b/shi7/shi7.py
@@ -102,21 +102,26 @@ def whitelist(dir, whitelist):
 
 def read_fastq(fh):
     # Assume linear FASTQS
+    count = 0
     while True:
         title = next(fh)
+        count += 1
         while title[0] != '@':
             title = next(fh)
         # Record begins
         if title[0] != '@':
-            raise IOError('Malformed FASTQ files; verify they are linear and contain complete records.')
+            raise IOError('Malformed FASTQ files; verify they are linear and contain complete records - Title line does not begin with "@" symbol - error on line' + str(count) + '.')
         title = title[1:].strip()
         sequence = next(fh).strip()
+        count += 1
         garbage = next(fh).strip()
+        count += 1
         if garbage[0] != '+':
-            raise IOError('Malformed FASTQ files; verify they are linear and contain complete records.')
+            raise IOError('Malformed FASTQ files; verify they are linear and contain complete records - strand line does not contain "+" symbol on line' + str(count) + '.')
         qualities = next(fh).strip()
+        count += 1
         if len(qualities) != len(sequence):
-            raise IOError('Malformed FASTQ files; verify they are linear and contain complete records.')
+            raise IOError('Malformed FASTQ files; verify they are linear and contain complete records - Sequence length does not equal quality score length on line ' + str(count) + '.')
         yield title, sequence, qualities
 
 def split_fwd_rev(paths):


### PR DESCRIPTION
When shi7.py encounters a malformed FASTQ file, the error message now states what was wrong - missing @ symbol, missing + sign for strand, or sequence length doesn't equal quality score length.  Also displays the line where the issue occurs.