### PR TITLE
renamed legacy version var

### DIFF
--- a/shi7/shi7_learning.py
+++ b/shi7/shi7_learning.py
@@ -246,7 +246,7 @@ def main():
     args = parser.parse_args()
 
     learning_params = ["shi7.py"]
-    learning_pretty = ["SHI7 version",VERSION]
+    learning_pretty = ["SHI7 version", __version__]
     
     input = os.path.abspath(args.input)
     output = os.path.abspath(args.output)


### PR DESCRIPTION
v0.9.9 imported a variable `VERSION` at line 19, this was changed in v1.0.0 to `__version__`, but the legacy variable remains in v1.0.0 at line 249, which raises a NameError and the script fails